### PR TITLE
[Parallel Processing] Speedup downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ gytmdl can be configured using the command line arguments or the config file. Th
 | `--cover-size` | `cover_size` | Size of the cover. Can be any number between `0` and `16383`. `0` gets the highest resolution available. | `1200` |
 | `--cover-format` | `cover_format` | Format of the cover. Can be `jpg` or `png`. | `jpg` |
 | `--cover-quality` | `cover_quality` | JPEG quality of the cover. Can be any number between `0` and `100`. | `94` |
+| `--num-threads` | `num_threads` | Specify number of threads for parallel downloads `1` to `10`. | `1` |
 | `--final-path-structure` | `final_path_structure` | Structure of the final path as a format string. Possible variables are `album`, `album_artist`, `artist`, `media_type`, `rating`, `title`, `track`, `track_total` and `year`. | `{album_artist}/{album}/{track:02d} {title}` |
 | `-e`, `--exclude-tags` | `exclude_tags` | List of tags to exclude from file tagging separated by commas. Possible variables are `album`, `album_artist`, `artist`, `comment`, `cover`, `lyrics`, `media_type`, `rating`, `release_date`, `title`, `track` and `track_total`. | `null` |
 | `--truncate` | `truncate` | Maximum length of the file/folder names. | `40` |


### PR DESCRIPTION
This commit introduces parallel processing of tracks using a ThreadPoolExecutor to improve performance. It also ensures that each track is processed only once by using a synchronized set and a lock to manage track processing across threads.

use --num-thread to specify the number of parallel downloads. Default 1

Helps for downloading albums with a lot of tracks, eg audiobooks.