### PR TITLE
Store YouTube ID in a custom tag and check against it before download

### DIFF
--- a/gytmdl/cli.py
+++ b/gytmdl/cli.py
@@ -242,7 +242,8 @@ def cli(
     error_count = 0
     for i, url in enumerate(download_queue):
         for j, track in enumerate(url):
-            if track["id"] in already_downloaded_ids:
+            track_id = track["id"]
+            if track_id in already_downloaded_ids:
                 logger.info(
                     f'Skipping already downloaded track: {track["title"]}'
                 )
@@ -252,21 +253,21 @@ def cli(
             )
             try:
                 logger.debug("Getting tags")
-                ytmusic_watch_playlist = dl.get_ytmusic_watch_playlist(track["id"])
+                ytmusic_watch_playlist = dl.get_ytmusic_watch_playlist(track_id)
                 if ytmusic_watch_playlist is None:
                     logger.warning("Track is a video, using song equivalent")
-                    track["id"] = dl.search_track(track["title"])
-                    logger.debug(f'Video ID changed to "{track["id"]}"')
-                    ytmusic_watch_playlist = dl.get_ytmusic_watch_playlist(track["id"])
+                    track_id = dl.search_track(track["title"])
+                    logger.debug(f'Video ID changed to "{track_id}"')
+                    ytmusic_watch_playlist = dl.get_ytmusic_watch_playlist(track_id)
                 tags = dl.get_tags(ytmusic_watch_playlist)
                 tags["ytid"] = track["id"]
                 final_location = dl.get_final_location(tags)
                 logger.debug(f'Final location is "{final_location}"')
                 if not final_location.exists() or overwrite:
-                    temp_location = dl.get_temp_location(track["id"])
+                    temp_location = dl.get_temp_location(track_id)
                     logger.debug(f'Downloading to "{temp_location}"')
-                    dl.download(track["id"], temp_location)
-                    fixed_location = dl.get_fixed_location(track["id"])
+                    dl.download(track_id, temp_location)
+                    fixed_location = dl.get_fixed_location(track_id)
                     logger.debug(f'Remuxing to "{fixed_location}"')
                     dl.fixup(temp_location, fixed_location)
                     logger.debug("Applying tags")

--- a/gytmdl/dl.py
+++ b/gytmdl/dl.py
@@ -6,7 +6,7 @@ import subprocess
 from pathlib import Path
 
 import requests
-from mutagen.mp4 import MP4, MP4Cover
+from mutagen.mp4 import MP4, MP4Cover, MP4FreeForm
 from yt_dlp import YoutubeDL
 from ytmusicapi import YTMusic
 
@@ -21,7 +21,7 @@ MP4_TAGS_MAP = {
     "release_date": "\xa9day",
     "title": "\xa9nam",
 }
-
+YTID_TAG_KEY = "----:com.github.gytmdl:ytid"
 
 class Dl:
     def __init__(
@@ -256,6 +256,7 @@ class Dl:
             mp4_tags["trkn"][0][0] = tags["track"]
         if "track_total" not in self.exclude_tags:
             mp4_tags["trkn"][0][1] = tags["track_total"]
+        mp4_tags[YTID_TAG_KEY] = MP4FreeForm(tags["ytid"].encode())
         mp4 = MP4(fixed_location)
         mp4.clear()
         mp4.update(mp4_tags)


### PR DESCRIPTION
Hello, and thank you for your great work! I'm using this project to keep my local music in sync with a YouTube Music playlist. Unfortunately, because the script is downloading info for each song in playlist, no matter if it was or not downloaded before, it takes a bit until finishes if there isn't any new song to download.

This PR changes this by adding a custom field to the saved file where it stores the origin YouTube ID. When the script is started again, it loops through all the m4a files in the target destination, collects the YouTube IDs from the MP4 tags and then skips those entries altogether when downloading. This ensures that the YouTube servers are not contacted for each already-downloaded file and also saves some time by not retrieving the tags.

I kept the old logic to support the use case where someone used this script in the past and his M4A files does not contain the new tag in them. 