### PR TITLE
Fix missing "track" tag in response from YouTube

### DIFF
--- a/gytmdl/cli.py
+++ b/gytmdl/cli.py
@@ -245,6 +245,8 @@ def cli(
                     logger.debug(f'Video ID changed to "{track["id"]}"')
                     ytmusic_watch_playlist = dl.get_ytmusic_watch_playlist(track["id"])
                 tags = dl.get_tags(ytmusic_watch_playlist)
+                if not "track" in tags:
+                    tags["track"] = 1
                 final_location = dl.get_final_location(tags)
                 logger.debug(f'Final location is "{final_location}"')
                 if not final_location.exists() or overwrite:


### PR DESCRIPTION
I encountered some tracks having no "track" tag in the response from `Dl.get_tags`. Because the app relies on having this tag (when determining the filename), for this cases I added a fake track number immediately after retrieving the tags.

An example of a song without a "track" tag: https://music.youtube.com/watch?v=PsXNBR-zIww