### PR TITLE
Add --cookies-from-browser option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ gytmdl can be configured using the command line arguments or the config file. Th
 | `-f`, `--final-path` / `final_path` | Path where the downloaded files will be saved. | `./YouTube Music` |
 | `-t`, `--temp-path` / `temp_path` | Path where the temporary files will be saved. | `./temp` |
 | `-c`, `--cookies-location` / `cookies_location` | Location of the cookies file. | `null` |
+| `--cookies-from-browser` / `cookies_from_browser` | Name of browser to load cookies from (passed to yt-dlp). | `null` |
 | `--ffmpeg-location` / `ffmpeg_location` | Location of the FFmpeg binary. | `ffmpeg` |
 | `--config-location` / - | Location of the config file. | `<home folder>/.gytmdl/config.json` |
 | `-i`, `--itag` / `itag` | Itag (audio quality). | `140` |

--- a/gytmdl/cli.py
+++ b/gytmdl/cli.py
@@ -77,6 +77,12 @@ def no_config_callback(
     help="Location of the cookies file.",
 )
 @click.option(
+    "--cookies-from-browser",
+    type=str,
+    default=None,
+    help="Name of browser to load cookies from. See yt-dlp manual for details."
+)
+@click.option(
     "--ffmpeg-location",
     type=Path,
     default="ffmpeg",
@@ -183,6 +189,7 @@ def cli(
     final_path: Path,
     temp_path: Path,
     cookies_location: Path,
+    cookies_from_browser: str,
     ffmpeg_location: Path,
     config_location: Path,
     itag: str,
@@ -211,6 +218,9 @@ def cli(
         return
     if cookies_location is not None and not cookies_location.exists():
         logger.critical(f'Cookies file not found at "{cookies_location}"')
+        return
+    if cookies_location is not None and cookies_from_browser is not None:
+        logger.critical('Cannot use both --cookies-location and --cookies-from-browser')
         return
     if url_txt:
         logger.debug("Reading URLs from text files")


### PR DESCRIPTION
yt-dlp can retrieve YouTube cookies from most browsers, which is far more convenient than manually extracting them.

This option has to be parsed in gytmdl unfortunately, the yt-dlp Python API expects a tuple. The code that parses it is here: https://github.com/yt-dlp/yt-dlp/blob/86a972033e05fea80e5fe7f2aff6723dbe2f3952/yt_dlp/__init__.py#L370